### PR TITLE
Added OTS recommendation validations

### DIFF
--- a/app/models/training/ots/recommendation.rb
+++ b/app/models/training/ots/recommendation.rb
@@ -13,9 +13,51 @@ class Training::Ots::Recommendation < ApplicationRecord
           class_name: "Training::Ots::Result",
           dependent:  :destroy
 
+  # ActiveRecord validations
+  validate :permit_not_passed
+  validate :permit_only_higher_rating
+  validate :permit_only_one
+
+  # ActiveRecord scopes
   scope :pending, -> do
     left_outer_joins(:result).where(
       training_ots_results: { recommendation_id: nil }
     )
   end
+
+  private
+
+    # Validates that no additional recommendations can be added
+    # for a rating in which the user has successfully passed
+    # an OTS
+    #
+    def permit_not_passed
+      user.ots_results.each do |result|
+        if result.rating == rating && result.pass?
+          errors.add :rating, "already passed"
+        end
+      end
+    end
+
+    # Validates that no recommendations can be added for a lower
+    # rating than the user currently has.
+    #
+    # This check is useful in addition to #permit_not_passed in the
+    # event that an OTS was passed but the user's rating has not yet
+    # been updated for some reason.
+    #
+    def permit_only_higher_rating
+      if rating.vatsim_id < user.rating.vatsim_id
+        errors.add :rating, "lower than user's current rating"
+      end
+    end
+
+    # Validates that a user can have only one pending (uncompleted)
+    # OTS recommendation at a time
+    #
+    def permit_only_one
+      unless user.ots_recommendations.pending.empty?
+        errors.add :user, "already has a pending OTS recommendation"
+      end
+    end
 end

--- a/app/models/training/ots/result.rb
+++ b/app/models/training/ots/result.rb
@@ -8,7 +8,8 @@ class Training::Ots::Result < ApplicationRecord
   belongs_to :recommendation, class_name: "Training::Ots::Recommendation"
   belongs_to :instructor, class_name: "User"
 
-  has_one :user, through: :recommendation
+  has_one :user,   through: :recommendation
+  has_one :rating, through: :recommendation
 
   # ActiveRecord validations
   validates :recommendation, uniqueness: true

--- a/spec/models/training/ots/recommendation_spec.rb
+++ b/spec/models/training/ots/recommendation_spec.rb
@@ -39,4 +39,35 @@ RSpec.describe Training::Ots::Recommendation, type: :model do
       expect(Training::Ots::Recommendation.pending.count).to eq 5
     end
   end
+
+  describe "#permit_not_passed" do
+    it "is not valid if the user has already passed an OTS for the rating" do
+      ots_result = create(:training_ots_result, pass: true)
+
+      new_ots = build :training_ots_recommendation,
+                      user:   ots_result.user,
+                      rating: ots_result.rating
+
+      expect(new_ots).to_not be_valid
+    end
+  end
+
+  describe "#permit_only_higher_rating" do
+    it "is not valid for a rating lower than the user already has" do
+      usr_rating = create(:vatsim_rating, vatsim_id: 3)
+      ots_rating = create(:vatsim_rating, vatsim_id: 2)
+      user       = create(:user, rating: usr_rating)
+
+      ots = build(:training_ots_recommendation, user: user, rating: ots_rating)
+      expect(ots).to_not be_valid
+    end
+  end
+
+  describe "#permit_only_one" do
+    it "is not valid if a user has an existing pending recommendation" do
+      user = create(:user)
+      create(:training_ots_recommendation, user: user)
+      expect(build(:training_ots_recommendation, user: user)).to_not be_valid
+    end
+  end
 end

--- a/spec/models/training/ots/result_spec.rb
+++ b/spec/models/training/ots/result_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Training::Ots::Result, type: :model do
     it { expect(result).to belong_to(:recommendation) }
     it { expect(result).to belong_to(:instructor) }
     it { expect(result).to have_one(:user) }
+    it { expect(result).to have_one(:rating) }
   end
 
   describe "ActiveRecord validations" do


### PR DESCRIPTION
- Validates that only one pending OTS recommendation can exist for a user at a time
- Validates that OTS recommendations must be for a higher rating than the user currently has
- Validates that OTS recommendations cannot be for an OTS they already passed