### PR TITLE
Addressed race condition issue with training progress

### DIFF
--- a/spec/factories/training_progresses.rb
+++ b/spec/factories/training_progresses.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     association :session, factory: :training_session
 
     started_at { Time.now.utc }
+
+    trait :completed do
+      completed_at { Time.now.utc }
+    end
   end
 end

--- a/spec/models/training/progress_spec.rb
+++ b/spec/models/training/progress_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Training::Progress, type: :model do
   describe "ActiveRecord scopes" do
     describe "#completed" do
       it "returns an array of completed training blocks" do
-        create_list(:training_progress, 5, completed_at: Time.now.utc + 1.second)
+        create_list(:training_progress, 5, :completed)
         expect(Training::Progress.completed.count).to eq 5
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe Training::Progress, type: :model do
 
   describe "#completed?" do
     it "returns true when a completion date is set" do
-      progression = build(:training_progress, completed_at: Time.now.utc)
+      progression = build(:training_progress, :completed)
       expect(progression.completed?).to eq true
     end
 


### PR DESCRIPTION
Added a factory trait to build a completed training progress block. This should address the timing race condition.